### PR TITLE
情報ID (res['_id']) が同じとき、メッセージを送信せずに編集する

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -50,12 +50,29 @@ class MyBot(commands.Bot):
         else:
             await bot.change_presence(activity=discord.Game(name=STATUS_MESSAGE, type=1))
         logger.info('-----')
+
+        # 送信済みの情報ID, メッセージIDを格納
+        # ID_LOGGER = {
+        #  "_id":[
+        #    "message_id",
+        #    "message_id", ...
+        #  ],
+        #  "_id":[], ...
+        # }
+        ID_LOGGER = {}
+
         while True:
-            data = await main()
+            data, _id = await main() # データ, 情報IDを受け取る
             if data != None:
-                for i in channel_list:
-                    channel = bot.get_channel(i)
-                    await channel.send(embed=data)
+                mes_id = [] # 一時的にメッセージIDを格納するリスト
+                if _id in ID_LOGGER:
+                    for i in ID_LOGGER.get(_id, []):
+                        mes_id.append(await i.edit(embed=data))  # 送信内容の編集
+                else:
+                    for i in channel_list:
+                        channel = bot.get_channel(i)
+                        mes_id.append(await channel.send(embed=data))
+                ID_LOGGER[_id] = mes_id # 送信済みのメッセージIDリストの更新
 
 
 # MyBotのインスタンス化及び起動処理。

--- a/src/modules/earthquake.py
+++ b/src/modules/earthquake.py
@@ -5,7 +5,6 @@ import datetime
 from header.logger import *
 # https://www.p2pquake.net/json_api_v2/#/P2P%E5%9C%B0%E9%9C%87%E6%83%85%E5%A0%B1%20API/get_history
 
-
 async def main():
     url = "wss://api.p2pquake.net/v2/ws"
     async with websockets.connect(url) as websocket:
@@ -15,8 +14,6 @@ async def main():
     logger.info('code: '+str(code))
     logger.info('id: '+str(res['_id']))
     logger.debug(str(res))
-
-
     # 551(地震情報)、552(津波予報)、554(緊急地震速報 発表検出)、555(各地域ピア数)、561(地震感知情報)、9611(地震感知情報 解析結果)
     if code == 551:
         title,description = await earthquake_information(res)

--- a/src/modules/earthquake.py
+++ b/src/modules/earthquake.py
@@ -29,7 +29,8 @@ async def main():
     if title != None:
         res_emb = await create_embed(title,description,code)
         time = str(datetime.datetime.strptime(res['earthquake']['time'], '%Y/%m/%d %H:%M:%S').strftime('%Y%m%d%H%M%S'))
-        return res_emb, str(res['code'])+'_'+time # データ, 情報IDを返す
+        _id = str(res['code'])+'_'+time # --> ex: 551_202203280000
+        return res_emb, _id # データ, 情報IDを返す
 
 async def create_embed(title:str,description:str,code:int):
     object_embed = discord.Embed(

--- a/src/modules/earthquake.py
+++ b/src/modules/earthquake.py
@@ -26,12 +26,12 @@ async def main():
     logger.debug(str(res))
 
     # 既に同じIDの情報を処理したかの判定
-    if res['id'] in ID_LOGGER.get(res['code'], []):
+    if res['_id'] in ID_LOGGER.get(res['code'], []):
         return None
     else:
         if not ID_LOGGER.get(res['code'], False):
             ID_LOGGER[res['code']] == []
-        ID_LOGGER[res['code']].append(res['id'])
+        ID_LOGGER[res['code']].append(res['_id'])
 
     # 551(地震情報)、552(津波予報)、554(緊急地震速報 発表検出)、555(各地域ピア数)、561(地震感知情報)、9611(地震感知情報 解析結果)
     if code == 551:

--- a/src/modules/earthquake.py
+++ b/src/modules/earthquake.py
@@ -5,15 +5,6 @@ import datetime
 from header.logger import *
 # https://www.p2pquake.net/json_api_v2/#/P2P%E5%9C%B0%E9%9C%87%E6%83%85%E5%A0%B1%20API/get_history
 
-# 各情報のIDを格納する データ構造の例
-# ID_LOGGER = {
-#   511: [
-#     ID,
-#     ID, ...
-#   ],
-#  552: [ ... ],
-# }
-ID_LOGGER = {}
 
 async def main():
     url = "wss://api.p2pquake.net/v2/ws"
@@ -25,13 +16,6 @@ async def main():
     logger.info('id: '+str(res['_id']))
     logger.debug(str(res))
 
-    # 既に同じIDの情報を処理したかの判定
-    if res['_id'] in ID_LOGGER.get(res['code'], []):
-        return None
-    else:
-        if not ID_LOGGER.get(res['code'], False):
-            ID_LOGGER[res['code']] == []
-        ID_LOGGER[res['code']].append(res['_id'])
 
     # 551(地震情報)、552(津波予報)、554(緊急地震速報 発表検出)、555(各地域ピア数)、561(地震感知情報)、9611(地震感知情報 解析結果)
     if code == 551:
@@ -46,7 +30,8 @@ async def main():
     logger.info('title: %s',title)
     logger.info('description: %s',description)
     if title != None:
-        return await create_embed(title,description,code)
+        res_emb = await create_embed(title,description,code)
+        return res_emb, str(res['_id']) # データ, 情報IDを返す
 
 async def create_embed(title:str,description:str,code:int):
     object_embed = discord.Embed(

--- a/src/modules/earthquake.py
+++ b/src/modules/earthquake.py
@@ -28,7 +28,8 @@ async def main():
     logger.info('description: %s',description)
     if title != None:
         res_emb = await create_embed(title,description,code)
-        return res_emb, str(res['_id']) # データ, 情報IDを返す
+        time = str(datetime.datetime.strptime(res['earthquake']['time'], '%Y/%m/%d %H:%M:%S').strftime('%Y%m%d%H%M%S'))
+        return res_emb, str(res['code'])+'_'+time # データ, 情報IDを返す
 
 async def create_embed(title:str,description:str,code:int):
     object_embed = discord.Embed(


### PR DESCRIPTION
- earthquake.pyのmain関数の戻り値を「データ」から「データ, 情報ID」に変更
- main.pyは情報ID, メッセージIDを格納しておく `ID_LOGGER` を持つようにし、情報IDが存在すればそのメッセージIDに対して編集を行う

動くかは分からない。